### PR TITLE
Update StyleCop to 6.1

### DIFF
--- a/SourceAnalysisPolicy/CheckinPolicy.csproj
+++ b/SourceAnalysisPolicy/CheckinPolicy.csproj
@@ -160,14 +160,14 @@
       <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\stdole.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StyleCop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
-      <HintPath>..\packages\StyleCop.6.0.0\lib\net40\StyleCop.dll</HintPath>
+    <Reference Include="StyleCop, Version=6.1.0.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
+      <HintPath>..\packages\StyleCop.6.1.0\lib\net40\StyleCop.dll</HintPath>
     </Reference>
-    <Reference Include="StyleCop.CSharp, Version=6.0.0.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
-      <HintPath>..\packages\StyleCop.CSharp.6.0.0\lib\net40\StyleCop.CSharp.dll</HintPath>
+    <Reference Include="StyleCop.CSharp, Version=6.1.0.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
+      <HintPath>..\packages\StyleCop.CSharp.6.1.0\lib\net40\StyleCop.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="StyleCop.CSharp.Rules, Version=6.0.0.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
-      <HintPath>..\packages\StyleCop.CSharp.Rules.6.0.0\lib\net40\StyleCop.CSharp.Rules.dll</HintPath>
+    <Reference Include="StyleCop.CSharp.Rules, Version=6.1.0.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
+      <HintPath>..\packages\StyleCop.CSharp.Rules.6.1.0\lib\net40\StyleCop.CSharp.Rules.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/SourceAnalysisPolicy/packages.config
+++ b/SourceAnalysisPolicy/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="6.0.0" targetFramework="net45" />
-  <package id="StyleCop.CSharp" version="6.0.0" targetFramework="net45" />
-  <package id="StyleCop.CSharp.Rules" version="6.0.0" targetFramework="net45" />
+  <package id="StyleCop" version="6.1.0" targetFramework="net45" />
+  <package id="StyleCop.CSharp" version="6.1.0" targetFramework="net45" />
+  <package id="StyleCop.CSharp.Rules" version="6.1.0" targetFramework="net45" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net45" />
   <package id="VSSDK.GraphModel" version="11.0.4" targetFramework="net45" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net45" />


### PR DESCRIPTION
Update StyleCop to 6.1 to include the fixes described at:
https://www.nuget.org/packages/StyleCop/